### PR TITLE
Refresh screen after running `!npm repo`

### DIFF
--- a/plugin/github_link_opener.vim
+++ b/plugin/github_link_opener.vim
@@ -20,7 +20,7 @@ function! s:OpenGitHubLink()
     let re_scoped_or_nonscoped_npm_package = '\v[''"]\zs((\@(\w+[-.]?)+\/(\w+[-.]?)+)|(\w+[-.]?)+)'
     let package = matchstr(getline('.'), re_scoped_or_nonscoped_npm_package)
     if !empty(package)
-      silent execute '!npm repo ' . package
+      silent execute '!npm repo ' . package | redraw!
     endif
   elseif empty(path) || has_more_than_one_slash
     " Default behavior of `gx`


### PR DESCRIPTION
Since `npm repo` prints output, it causes Vim to show a corrupted buffer after it finishes. There's an issue with a bit of detail here: https://github.com/vim/vim/issues/1253

The solution is to run `redraw!` so that Vim repaints the screen and the buffer looks just the same as it did before running `!npm repo`.