### PR TITLE
Open ruby require/gem names using octolinker api

### DIFF
--- a/plugin/github_link_opener.vim
+++ b/plugin/github_link_opener.vim
@@ -1,3 +1,13 @@
+let s:PACKAGE_REGISTRIES = { 'ruby': 'rubygems' }
+
+function! s:RequestPackageUrl(package)
+  let api_url = 'https://octolinker-api.now.sh/?' . s:PACKAGE_REGISTRIES[&ft] . '='
+  let request_url = api_url . a:package
+  let response = webapi#http#get(request_url)
+  let content = webapi#json#decode(response.content)
+  return get(content.result[0], 'result', '')
+endfunction
+
 " Shamelessly cribbed from https://github.com/christoomey/vim-quicklink
 function! s:OpenWithNetrw(url)
   if has("patch-7.4.567")
@@ -13,6 +23,7 @@ function! s:OpenGitHubLink()
   let path = matchstr(word, chars . '/' . chars)
   let has_more_than_one_slash = word =~# '/.\+/'
   let line_has_js_package = getline('.') =~# '\<\(require\|import\|from\)\>'
+  let line_has_ruby_package = getline('.') =~# '\<\(require\|gem\)\>'
   if &ft ==# 'go' && has_more_than_one_slash
     let url = matchstr(word, chars . '/' . chars . '/' . chars)
     call s:OpenWithNetrw("https://" . url)
@@ -21,6 +32,22 @@ function! s:OpenGitHubLink()
     let package = matchstr(getline('.'), re_scoped_or_nonscoped_npm_package)
     if !empty(package)
       silent execute '!npm repo ' . package | redraw!
+    endif
+  elseif &ft ==# 'ruby' && line_has_ruby_package
+    let package_split_slash = split(matchstr(getline('.'), '\v[''"]\zs(\w[-/]?)+\ze'), '/')
+    if empty(package_split_slash) | return | endif
+
+    if len(package_split_slash) > 1
+      let package_slash_to_dash = join(package_split_slash, '-')
+      let url = s:RequestPackageUrl(package_slash_to_dash)
+      if !empty(url)
+        call s:OpenWithNetrw(url) | return
+      endif
+    endif
+
+    let url = s:RequestPackageUrl(package_split_slash[0])
+    if !empty(url)
+      call s:OpenWithNetrw(url)
     endif
   elseif empty(path) || has_more_than_one_slash
     " Default behavior of `gx`


### PR DESCRIPTION
[OctoLinker](https://octolinker.now.sh/) is a popular Chrome extension (25k users, ~5 years old) that converts import statements into links. There is a public [api](https://github.com/OctoLinker/api) that can fairly easily be integrated here. I'm not sure if I should be asking permission before using it like this - they have an [issue](https://github.com/OctoLinker/OctoLinker/issues/280) discussing editor extensions and seem open to it though.

Note that this would add https://github.com/mattn/webapi-vim as a dependency (you mention vim-quicklink in the README so I suspect this is fine).

What do you think?