### PR TITLE
Correct `Plug` install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ working too.
 
 With [vim-plug](https://github.com/junegunn/vim-plug):
 
-    Plug 'gabebw/vim-github-link-opener'
+    Plug 'gabebw/vim-github-link-opener', {'branch': 'main'}
 
 Then run `:PlugInstall`.


### PR DESCRIPTION
Due to there no longer being a `master` branch for this repo, specifying this like this was giving this error:

```
- Finishing ... Done!               
x vim-github-link-opener:           
    fatal: invalid reference: master
```

I believe due to vim-plug defaulting to `master` when no branch is specified. This commit fixes this.

Thanks!